### PR TITLE
Config changes + new errors + new tests

### DIFF
--- a/cmd/image-previewer/main.go
+++ b/cmd/image-previewer/main.go
@@ -28,8 +28,8 @@ func main() {
 		logger.Named("main").Error("Config parse error", zap.Error(err))
 	}
 
-	app := app.New(config.Cache, logger.Named("app"))
-	server := server.New(config.HTTP, app, logger.Named("server"))
+	app := app.New(config.Cache.MaxElemCnt, config.Cache.Dir, config.Proxy.Timeout, logger.Named("app"))
+	server := server.New(config.HTTP.Port, app, logger.Named("server"))
 
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 	defer cancel()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       HTTP_PORT: 8080
       CACHE_MAX_ELEM_CNT: 50
+      PROXY_TIMEOUT: 2
     ports:
       - "8080:8080"
 

--- a/internal/app/errors.go
+++ b/internal/app/errors.go
@@ -1,0 +1,11 @@
+package app
+
+import "errors"
+
+var (
+	ErrProxyResponseNotOk = errors.New("image proxy server response not ok")
+	ErrProxyGetImage      = errors.New("image proxy error")
+	ErrImageFormat        = errors.New("image format not supported")
+	ErrFileNotAnImage     = errors.New("file is not an image")
+	ErrResizeImage        = errors.New("resize image error")
+)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 type Config struct {
 	HTTP  *HTTPConfig
 	Cache *CacheConfig
+	Proxy *ProxyConfig
 }
 
 type HTTPConfig struct {
@@ -19,6 +20,10 @@ type HTTPConfig struct {
 type CacheConfig struct {
 	MaxElemCnt int    `env:"CACHE_MAX_ELEM_CNT" default:"50"`
 	Dir        string `env:"CACHE_DIR" default:"./filecache"`
+}
+
+type ProxyConfig struct {
+	Timeout int `env:"PROXY_TIMEOUT" default:"2"`
 }
 
 func New() (*Config, error) {
@@ -32,7 +37,12 @@ func New() (*Config, error) {
 		return nil, err
 	}
 
-	return &Config{HTTP: httpCnf, Cache: cacheCnf}, nil
+	proxyCnf := &ProxyConfig{}
+	if err := parseEnv(proxyCnf); err != nil {
+		return nil, err
+	}
+
+	return &Config{HTTP: httpCnf, Cache: cacheCnf, Proxy: proxyCnf}, nil
 }
 
 func parseEnv(cnf interface{}) error {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -19,11 +19,15 @@ func TestConfig(t *testing.T) {
 		testCacheDir := "/tmp/cache"
 		os.Setenv("CACHE_DIR", testCacheDir)
 
+		testProxyTimeout := 12
+		os.Setenv("PROXY_TIMEOUT", strconv.Itoa(testProxyTimeout))
+
 		cnf, err := New()
 		require.NoError(t, err)
 
 		require.Equal(t, testPort, cnf.HTTP.Port)
 		require.Equal(t, testCacheSize, cnf.Cache.MaxElemCnt)
 		require.Equal(t, testCacheDir, cnf.Cache.Dir)
+		require.Equal(t, testProxyTimeout, cnf.Proxy.Timeout)
 	})
 }

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -9,8 +9,6 @@ var (
 	ErrInvalidURL           = errors.New("invalid image URL")
 )
 
-// type ResponseErrorCode string
-
 const (
 	ErrProxyNotOkResponse     string = "err_get_image_http_not_ok"
 	ErrProxyGetImageResponse  string = "err_get_image"

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -8,3 +8,14 @@ var (
 	ErrInvalidTargetHeight  = errors.New("invalid target image heigth")
 	ErrInvalidURL           = errors.New("invalid image URL")
 )
+
+// type ResponseErrorCode string
+
+const (
+	ErrProxyNotOkResponse     string = "err_get_image_http_not_ok"
+	ErrProxyGetImageResponse  string = "err_get_image"
+	ErrImageResizeResponse    string = "err_image_resize"
+	ErrImageFormatResponse    string = "err_image_format"
+	ErrFileNotAnImageResponse string = "err_not_an_image"
+	ErrUnknownResponse        string = "err_unknown"
+)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,32 +8,32 @@ import (
 	"time"
 
 	"github.com/shimmy8/image-previewer/internal/app"
-	"github.com/shimmy8/image-previewer/internal/config"
 	"go.uber.org/zap"
 )
 
 type Server struct {
-	config *config.HTTPConfig
-	app    *app.App
+	port int
+
+	app *app.App
 
 	server *http.Server
 	logger *zap.Logger
 }
 
-func New(config *config.HTTPConfig, app *app.App, logger *zap.Logger) *Server {
-	return &Server{config: config, app: app, server: nil, logger: logger}
+func New(port int, app *app.App, logger *zap.Logger) *Server {
+	return &Server{port: port, app: app, server: nil, logger: logger}
 }
 
 func (s *Server) Start(ctx context.Context) error {
 	handler := NewHandler(ctx, s.app, s.logger)
 
 	s.server = &http.Server{
-		Addr:              ":" + strconv.Itoa(s.config.Port),
+		Addr:              ":" + strconv.Itoa(s.port),
 		Handler:           handler,
 		ReadHeaderTimeout: time.Second * 1,
 	}
 
-	s.logger.Info("Starting server", zap.Int("port", s.config.Port))
+	s.logger.Info("Starting server", zap.Int("port", s.port))
 
 	if err := s.server.ListenAndServe(); err != nil {
 		if !errors.Is(err, http.ErrServerClosed) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -7,15 +7,13 @@ import (
 	"testing"
 
 	"github.com/shimmy8/image-previewer/internal/app"
-	"github.com/shimmy8/image-previewer/internal/config"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
 
 func TestServerErrors(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
-	config, _ := config.New()
-	mockApp := app.New(config.Cache, logger)
+	mockApp := app.New(10, "./", 2, logger)
 
 	mockHandler := Handler{app: mockApp, logger: logger}
 

--- a/internal/service/cache/cache.go
+++ b/internal/service/cache/cache.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-
-	"github.com/shimmy8/image-previewer/internal/config"
 )
 
 type LruCache struct {
@@ -24,11 +22,11 @@ type cacheItem struct {
 	key      string
 }
 
-func New(conf *config.CacheConfig) *LruCache {
-	cache := &LruCache{maxSize: conf.MaxElemCnt, queue: NewList(), dir: conf.Dir}
+func New(maxSize int, cacheDir string) *LruCache {
+	cache := &LruCache{maxSize: maxSize, queue: NewList(), dir: cacheDir}
 
-	if _, err := os.Stat(conf.Dir); os.IsNotExist(err) {
-		dirErr := os.MkdirAll(conf.Dir, os.ModePerm)
+	if _, err := os.Stat(cacheDir); os.IsNotExist(err) {
+		dirErr := os.MkdirAll(cacheDir, os.ModePerm)
 		if dirErr != nil {
 			log.Panic("Cache dir unavaildable")
 		}

--- a/internal/service/cache/cache_test.go
+++ b/internal/service/cache/cache_test.go
@@ -7,13 +7,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/shimmy8/image-previewer/internal/config"
 	"github.com/stretchr/testify/require"
 )
 
 func TestCacheGetSet(t *testing.T) {
 	cacheFolder := "./testcache"
-	diskCache := New(&config.CacheConfig{MaxElemCnt: 4, Dir: cacheFolder})
+	diskCache := New(4, cacheFolder)
 	cacheBytes := []byte("some")
 
 	defer func() { os.RemoveAll(cacheFolder) }()
@@ -36,7 +35,7 @@ func TestCacheGetSet(t *testing.T) {
 
 	t.Run("test cache max size", func(t *testing.T) {
 		cacheFolder2 := "./testcache2"
-		newCache := New(&config.CacheConfig{MaxElemCnt: 2, Dir: cacheFolder2})
+		newCache := New(2, cacheFolder2)
 
 		defer func() { os.RemoveAll(cacheFolder2) }()
 
@@ -93,7 +92,7 @@ func TestCahceLoad(t *testing.T) {
 	require.NoError(t, writeErr)
 
 	t.Run("test cache load from folder", func(t *testing.T) {
-		diskCache := New(&config.CacheConfig{MaxElemCnt: 2, Dir: cacheFolder})
+		diskCache := New(2, cacheFolder)
 
 		time.Sleep(time.Millisecond * 1)
 

--- a/internal/service/imgproxy/imgproxy.go
+++ b/internal/service/imgproxy/imgproxy.go
@@ -4,16 +4,22 @@ import (
 	"context"
 	"io"
 	"net/http"
+	"time"
 )
 
-type ImgProxy struct{}
+type ImgProxy struct {
+	timeout int
+}
 
-func New() *ImgProxy {
-	return &ImgProxy{}
+func New(timeout int) *ImgProxy {
+	return &ImgProxy{timeout: timeout}
 }
 
 func (iprx *ImgProxy) GetImage(ctx context.Context, url string, headers map[string][]string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	rqCtx, cancel := context.WithTimeout(ctx, time.Second*time.Duration(iprx.timeout))
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(rqCtx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/resizer/errors.go
+++ b/internal/service/resizer/errors.go
@@ -2,4 +2,7 @@ package resizer
 
 import "errors"
 
-var ErrFormatNotSupported = errors.New("format not supported")
+var (
+	ErrFormatNotSupported = errors.New("format not supported")
+	ErrNotAnImage         = errors.New("not an image")
+)

--- a/internal/service/resizer/resizer.go
+++ b/internal/service/resizer/resizer.go
@@ -2,6 +2,8 @@ package resizer
 
 import (
 	"bytes"
+	"errors"
+	"fmt"
 	"image"
 	"image/jpeg"
 	"image/png"
@@ -24,6 +26,9 @@ func (r *Resizer) ResizeImage(
 ) ([]byte, error) {
 	img, imgFmt, err := image.Decode(bytes.NewReader(imageBytes))
 	if err != nil {
+		if errors.Is(err, image.ErrFormat) {
+			return nil, fmt.Errorf("%w: %w", ErrNotAnImage, err)
+		}
 		return nil, err
 	}
 

--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -e
-
-echo -n "------ TEST SUCCESSFUL RESIZE"
-# TODO

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -124,29 +124,29 @@ func TestResizeErrors(t *testing.T) {
 
 		require.NoError(t, writeErr)
 
-		nginxFileUrl := fmt.Sprintf("http://localhost:80/images/%s", imgCopyFilename)
+		nginxFileURL := fmt.Sprintf("http://localhost:80/images/%s", imgCopyFilename)
 		// make sure file created
-		ngnixStatus, _ := makeRequest(nginxFileUrl)
+		ngnixStatus, _ := makeRequest(nginxFileURL)
 		require.Equal(t, http.StatusOK, ngnixStatus)
 
-		resizeUrl := fmt.Sprintf(
+		resizeURL := fmt.Sprintf(
 			"http://localhost:8080/fill/100/50/http:/nginx/images/%s",
 			imgCopyFilename,
 		)
 
 		// request file size change with new filename
-		status, _ := makeRequest(resizeUrl)
+		status, _ := makeRequest(resizeURL)
 		require.Equal(t, http.StatusOK, status)
 
 		// now delete file from disk
 		os.Remove(imgCopyFullName)
 		// make sure file deleted
-		ngnixRepStatus, _ := makeRequest(nginxFileUrl)
+		ngnixRepStatus, _ := makeRequest(nginxFileURL)
 		require.Equal(t, http.StatusNotFound, ngnixRepStatus)
 
 		// requiest a resize again
-		repStatus, _ := makeRequest(resizeUrl)
-		// voila! cached fili is still there
+		repStatus, _ := makeRequest(resizeURL)
+		// voila! cached file is still there
 		require.Equal(t, http.StatusOK, repStatus)
 	})
 }


### PR DESCRIPTION
1. Добавил тайм-аут прокси в конфиг
2. Поменял входные параметры для `*.New` функций (чтобы пакеты не импортировали конфиг)
3. Добавил коды ошибок для ответов сервера
4. Добавил интеграционные тесты для случаев:
- Сервер с картинкой не доступен
- Формат изображения не поддерживается
- По ссылке не изображение
- Превью сохранено в кэше, а само изображение в это время недоступно.